### PR TITLE
Introduced DJANGOROOT

### DIFF
--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -34,11 +34,11 @@ RUN set -x \
 ENV MEDIADIR=${ROOT}/media \
     STATICDIR=${ROOT}/static \
     RUNDIR=${ROOT}/run \
-    APPDIR=${ROOT}/src \
     PORT=8000 \
     UWSGIPORT=3031 \
     STATUSPORT=9191 \
     MANAGEFILE=manage.py \
+    DJANGOROOT=${SRCDIR} \
     WSGIFILE=wsgi.py
 
 # make directories
@@ -59,9 +59,6 @@ EXPOSE ${STATUSPORT}
 
 # expose uwsgi port
 EXPOSE ${UWSGIPORT}
-
-# set workdir
-WORKDIR ${APPDIR}
 
 # make symlink for run script
 RUN ln -s -f ${SCRIPTSDIR}/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile.j2
+++ b/Dockerfile.j2
@@ -34,6 +34,7 @@ RUN set -x \
 ENV MEDIADIR=${ROOT}/media \
     STATICDIR=${ROOT}/static \
     RUNDIR=${ROOT}/run \
+    APPDIR=${ROOT}/src \
     PORT=8000 \
     UWSGIPORT=3031 \
     STATUSPORT=9191 \
@@ -60,7 +61,7 @@ EXPOSE ${STATUSPORT}
 EXPOSE ${UWSGIPORT}
 
 # set workdir
-WORKDIR ${SRCDIR}
+WORKDIR ${APPDIR}
 
 # make symlink for run script
 RUN ln -s -f ${SCRIPTSDIR}/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ You will probably still need the following lines
     RUN pip install -r ${DEPLOYMENTDIR}/requirements.txt
     COPY . ${SRCDIR}
 
+**Important: If you update your 'DJANGOROOT' env variable, don't forget to update your WORKDIR to ${DJANGOROOT} as well:**
+
+    ENV DJANGOROOT ${SRCDIR}/my_django_root
+    ...
+    WORKDIR ${DJANGOROOT}
+
 
 ### docker-entrypoint.sh
 
@@ -40,7 +46,6 @@ Starts a Django development server.
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | No | Directory where the `manage.py` file is if not the root directory
 DJANGO_SETTINGS_MODULE | Yes | Name of the settings module
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 PORT | No | Provide the port on which the Django server should listen. Defaults to 8000
@@ -61,7 +66,6 @@ Runs the standard Django tests
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | No | Directory where the `manage.py` file is if not the root directory
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 
 #### tox
@@ -94,7 +98,6 @@ Run a Django Python shell
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | No | Directory where the `manage.py` file is if not the root directory
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 
 #### uwsgi
@@ -102,8 +105,8 @@ Run the app using uWSGI
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | No | Directory where the `manage.py` file is if not the root directory
-WSGIFILE | Yes | Provide name of `wsgi.py` relative to the root src directory
+DJANGOROOT | No | Directory where the `manage.py` file is if not the root directory. Defaults to `<ROOT>`
+WSGIFILE | No | Provide name of `wsgi.py` relative to the root django app directory. Defaults to `wsgi.py`
 DJANGO_SETTINGS_MODULE | Yes | Name of the settings module
 PORT | No | Port on which uWSGI will listen for HTTP connections. Defaults to 8000
 UWSGIPORT | No | Port on which uWSGI server will listen (use together with Nginx). Defaults to 3031

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Starts a Django development server.
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | Yes | Specify name of root src directory
+APPDIR | No | Directory where the `manage.py` file is if not the root directory
 DJANGO_SETTINGS_MODULE | Yes | Name of the settings module
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 PORT | No | Provide the port on which the Django server should listen. Defaults to 8000
@@ -61,7 +61,7 @@ Runs the standard Django tests
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | Yes | Specify name of root src directory
+APPDIR | No | Directory where the `manage.py` file is if not the root directory
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 
 #### tox
@@ -94,7 +94,7 @@ Run a Django Python shell
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | Yes | Specify name of root src directory
+APPDIR | No | Directory where the `manage.py` file is if not the root directory
 MANAGEFILE | No | Provide name of `manage.py` if it differs from `manage.py`
 
 #### uwsgi
@@ -102,7 +102,7 @@ Run the app using uWSGI
 
 Env variable | Required | Description
 --- | --- | ---
-APPDIR | Yes | Specify name of root src directory
+APPDIR | No | Directory where the `manage.py` file is if not the root directory
 WSGIFILE | Yes | Provide name of `wsgi.py` relative to the root src directory
 DJANGO_SETTINGS_MODULE | Yes | Name of the settings module
 PORT | No | Port on which uWSGI will listen for HTTP connections. Defaults to 8000

--- a/conf/uwsgi.template.ini
+++ b/conf/uwsgi.template.ini
@@ -1,8 +1,8 @@
 ; suppress inspection "DuplicateKeyInSection" for whole file
 [uwsgi]
-chdir = {{ env['SRCDIR'] }}/{{ env['APPDIR'] }}
-pythonpath = {{ env['PIPSRC'] }}:{{ env['SRCDIR'] }}:{{ env['SRCDIR'] }}/{{ env['APPDIR'] }}
-wsgi-file={{ env['SRCDIR']}}/{{ env['APPDIR'] }}/{{ env['WSGIFILE'] }}
+chdir = {{ env['DJANGOROOT'] }}
+pythonpath = {{ env['DJANGOROOT']}}:{{ env['PIPSRC'] }}:{{ env['SRCDIR'] }}
+wsgi-file={{ env['DJANGOROOT']}}/{{ env['WSGIFILE'] }}
 chmod-socket = 666
 env = DJANGO_SETTINGS_MODULE={{ env['DJANGO_SETTINGS_MODULE'] }}
 uid = www-data

--- a/scripts/docker-django-commands.sh
+++ b/scripts/docker-django-commands.sh
@@ -11,7 +11,7 @@ fi
 run_dev(){
     echo "Running Development Server..."
     export DJDEBUG=1
-    python ${APPDIR}/${MANAGEFILE} runserver 0.0.0.0:${PORT}
+    python ${MANAGEFILE} runserver 0.0.0.0:${PORT}
 }
 
 run_worker(){
@@ -25,11 +25,11 @@ run_worker(){
 
 run_django_tests(){
     echo "Running Django Tests..."
-    python ${APPDIR}/${MANAGEFILE} test
+    python ${MANAGEFILE} test
 }
 
 run_django_shell(){
-    python ${APPDIR}/${MANAGEFILE} shell
+    python ${MANAGEFILE} shell
 }
 
 run_uwsgi(){

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -12,18 +12,15 @@ Usage: docker run <imagename> COMMAND
 
 Commands
 
-dev      : Start a normal Django development server. Provide the 'APPDIR' env
-           which specifies the name of the dir that contains the manage.py file.
-           Provide 'MANAGEFILE' to be the name of the manage.py file.
-           Optionally provide the 'PORT' env
+dev      : Start a normal Django development server. Optionally provide the 'PORT' env
            variable to determine the port on which it listens.
 worker   : Start a celery worker. Requires the env variables 'CELERYAPP' and
            'CELERYWORKER_LOGLEVEL'
 bash     : Start a bash shell
-test     : Run the Django tests. Requires 'APPDIR' and 'MANAGEFILE'
+test     : Run the Django tests. Optionally provide custom 'MANAGEFILE'.
 tox      : Run the Tox tests. Requires 'TOXFILEDIR' and tox to be installed
-shell    : Start a Django Python shell. Requires 'APPDIR' and 'MANAGEFILE'
-uwsgi    : Run uwsgi server. Requires the env variables 'APPDIR', 'WSGIFILE',
+shell    : Start a Django Python shell. Optionally provide custom 'MANAGEFILE'.
+uwsgi    : Run uwsgi server. Requires the env variables 'DJANGOROOT', 'WSGIFILE' and
            'DJANGO_SETTINGS_MODULE'. Optional env variables are 'PORT',
            'UWSGIPORT' and 'STATUSPORT'.
 python   : Run a classic python shell


### PR DESCRIPTION
We need this because of the following scenario:

Consider the following folder layout:
```
/src/app/manage.py
/src/app/...
/src/tox.ini
/src/setup.py
/src/...
```

I want to be able to run:
```bash
docker-compose run someapp python manage.py migrate
```

This solution still supports the case:
```bash
docker-compose run someapp tox -e py276
```

Summary of the solution is to identify the DJANGOROOT as the 'default Django project root directory' containing the manage.py file, and make that the default working directory. Also this DJANGOROOT defaults to the same directory as the SRCDIR.
