### PR TITLE
Replace Python 2.7.11 target with 2.7.12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,9 @@ python_version = $(shell echo $@ | sed "s/[^-]*-python-\(.*\)/\1/")
 
 all: build push
 
-push: push-python-pypy-2.4.0 push-python-2.7.5 push-python-2.7.11 push-python-3.4.3 push-python-3.5.1
+push: push-python-pypy-2.4.0 push-python-2.7.5 push-python-2.7.12 push-python-3.4.3 push-python-3.5.1
 
-build: build-python-pypy-2.4.0 build-python-2.7.5 build-python-2.7.11 build-python-3.4.3 build-python-3.5.1
+build: build-python-pypy-2.4.0 build-python-2.7.5 build-python-2.7.12 build-python-3.4.3 build-python-3.5.1
 
 build-%: PYTHON_VERSION=$(python_version)
 build-%:


### PR DESCRIPTION
The latest 2.7.11 will continue being available, it just won't get updated.